### PR TITLE
Fix missing brace and remaining M:close()

### DIFF
--- a/lua/luajob.lua
+++ b/lua/luajob.lua
@@ -1,4 +1,4 @@
-local M = {
+local M = {}
 
 function M:new(o)
   o = o or {}
@@ -32,7 +32,7 @@ function M:shutdown(code, signal)
   if M.on_stderr then
       M.stderr:read_stop()
   end
-  M:close()
+  M:stop()
 end
 
 function M:options()


### PR DESCRIPTION
Making these changes seems to fix the errors I was getting in nvim.