### PR TITLE
Fix M:on_exit() -> M.on_exit()

### DIFF
--- a/lua/luajob.lua
+++ b/lua/luajob.lua
@@ -24,7 +24,7 @@ end
 
 function M.shutdown(code, signal)
   if M.on_exit then
-    M:on_exit(code, signal)
+    M.on_exit(code, signal)
   end
   if M.on_stdout then
       M.stdout:read_stop()


### PR DESCRIPTION
This allows `on_exit` not receive `self` and behave as documented.