### PR TITLE
Callbacks will now receive the running job as 'self'

### DIFF
--- a/lua/luajob.lua
+++ b/lua/luajob.lua
@@ -6,6 +6,12 @@ local function close_safely(handle)
   end
 end
 
+local function wrap_ctx(ctx, callback)
+  return function(err, data)
+    callback(ctx, err, data)
+  end
+end
+
 function M:new(o)
   o = o or {}
   for n,f in pairs(o) do
@@ -72,16 +78,16 @@ function M.options()
   return options
 end
 
-function M.start()
+function M.start(self)
   local options = M.options()
   M.handle = vim.loop.spawn(options.command,
     options,
-    vim.schedule_wrap(M.shutdown))
+    vim.schedule_wrap(wrap_ctx(self, M.shutdown)))
   if M.on_stdout then
-      M.stdout:read_start(vim.schedule_wrap(M.on_stdout))
+      M.stdout:read_start(vim.schedule_wrap(wrap_ctx(self, M.on_stdout)))
   end
   if M.on_stderr then
-      M.stderr:read_start(vim.schedule_wrap(M.on_stderr))
+      M.stderr:read_start(vim.schedule_wrap(wrap_ctx(self, M.on_stderr)))
   end
 end
 return M


### PR DESCRIPTION
Howdy!

While playing around with luajob, I found it a little strange that the callbacks do not seem to give access to the job object itself. While this is probably fine for piping output from an external process into a buffer, it makes it somewhat awkward to store & retrieve the result of the job.

For example, in the snippet in the README that uses 'git branch' to retrieve the current branch, it eventually needs to push that result into some kind of global scope via nvim_*_set_var(). It would be a lot cleaner if the result was simply stored back onto the job object itself, like so:

```
local luajob = require('luajob')
local git_branch = luajob:new({
  cmd = 'git branch',
  on_stdout = function(self, err, data)
    if err then
      print('error:', err)
    elseif data then
      lines = vim.fn.split(data, '\n')
      for _, line in ipairs(lines) do
        if line:find('*') then
          self.branch = (line:gsub('\n', ''))  --> store result back onto the job object
        end
      end
    end
  end,
  on_exit = function(self, err, data)
    print('job exited, branch: ', self.branch)  --> Read back the result on_exit or anywhere else where the job object is accessible
  end
})
git_branch:start()
```

Anyway, this little patch injects "self" into the callbacks `on_stdout`, `on_stderr`, and `on_exit`.